### PR TITLE
taking out mailto its only for gmail link

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,10 +25,10 @@
           <strong>Email: </strong> <a href=mailto:"Ramosjustin728@gmail.com"> Ramosjustin728@gmail.com</a>
         </li>
         <li id="gtihub"> 
-          <strong>GitHub: </strong> <a href=mailto:"https://github.com/JR728"> https://github.com/JR728</a>
+          <strong>GitHub: </strong> <a href="https://github.com/JR728"> https://github.com/JR728</a>
         </li>
         <li id="portfolio">
-          <strong>Portfolio: </strong> <a href=mailto:"">Coming Soon</a>
+          <strong>Portfolio: </strong> <a href="">Coming Soon</a>
         </li>
       </ul>
      </section>


### PR DESCRIPTION
links of git hub and portfolio got deleted "mailto:" 